### PR TITLE
pack tonTyp struct

### DIFF
--- a/src/ft2_replayer.h
+++ b/src/ft2_replayer.h
@@ -226,15 +226,19 @@ typedef struct songTyp_t
 	uint64_t musicTime64;
 } songTyp;
 
-typedef struct tonTyp_t
-{
-	uint8_t ton, instr, vol, effTyp, eff;
-} tonTyp;
-
 #ifdef _MSC_VER
 #pragma pack(push)
 #pragma pack(1)
 #endif
+
+typedef struct tonTyp_t
+{
+	uint8_t ton, instr, vol, effTyp, eff;
+}
+#ifdef __GNUC__
+__attribute__ ((packed))
+#endif
+tonTyp;
 
 typedef struct syncedChannel_t // used for audio/video sync queue
 {


### PR DESCRIPTION
Code throughout seem to expect sizeof(tonTyp) to be exactly 5 bytes,
which is the case if gcc is used, but, while porting to Plan 9, it was
found that sizeof is 8 bytes with some compilers instead, resulting in
either crashes on loading a module, or incorrect playback.