### PR TITLE
Minor quality of life improvements for macOS, now it works on Big Sur

### DIFF
--- a/src/ft2_audioselector.c
+++ b/src/ft2_audioselector.c
@@ -24,6 +24,9 @@ char *getAudioOutputDeviceFromConfig(void)
 	FILE *f = UNICHAR_FOPEN(editor.audioDevConfigFileLocation, "r");
 	if (f == NULL)
 	{
+#if defined(__APPLE__)
+		return NULL; // SDL doesn't return devices in any appreciable order, and device 0 is most certainly not guaranteed to be the current default device
+#else
 		const char *devStringTmp = SDL_GetAudioDeviceName(0, false);
 		if (devStringTmp == NULL)
 		{
@@ -35,6 +38,7 @@ char *getAudioOutputDeviceFromConfig(void)
 		if (devStringLen > 0)
 			strncpy(devString, devStringTmp, MAX_DEV_STR_LEN);
 		devString[devStringLen+1] = '\0'; // UTF-8 needs double null termination
+#endif
 	}
 	else
 	{

--- a/src/ft2_audioselector.c
+++ b/src/ft2_audioselector.c
@@ -54,6 +54,11 @@ char *getAudioOutputDeviceFromConfig(void)
 			devString[devStringLen-1]  = '\0';
 		devString[devStringLen+1] = '\0'; // UTF-8 needs double null termination
 
+#if defined(__APPLE__)
+		if (devString[0] == '\0')
+			return NULL; // macOS SDL2 locks up indefinitely if fed an empty string for device name
+#endif
+
 		fclose(f);
 	}
 

--- a/src/ft2_diskop.c
+++ b/src/ft2_diskop.c
@@ -2106,7 +2106,7 @@ static void setDiskOpItem(uint8_t item)
 	}
 
 	const int32_t pathLen = (int32_t)UNICHAR_STRLEN(FReq_CurPathU);
-	if (pathLen == 0)
+	if (pathLen == 0 && FReq_ModCurPathU[0] != '\0')
 	{
 		memset(FReq_CurPathU, 0, (PATH_MAX + 2) * sizeof (UNICHAR));
 		UNICHAR_STRCPY(FReq_CurPathU, FReq_ModCurPathU);


### PR DESCRIPTION
I don't know if either of these changes broke Big Sur on Intel, but at least the SDL default device one caused SDL2 to try to open my HDMI audio output, and somehow hang on that.