### PR TITLE
pack pal16

### DIFF
--- a/src/ft2_config.c
+++ b/src/ft2_config.c
@@ -70,6 +70,7 @@ static void loadConfigFromBuffer(bool defaults)
 {
 	lockMixerCallback();
 
+	assert(sizeof(config) == CONFIG_FILE_SIZE);
 	memcpy(&config, configBuffer, CONFIG_FILE_SIZE);
 
 	if (defaults)

--- a/src/ft2_palette.h
+++ b/src/ft2_palette.h
@@ -44,10 +44,21 @@ enum
 	PAL_NUM
 };
 
+#ifdef _MSC_VER
+#pragma pack(push)
+#pragma pack(1)
+#endif
 typedef struct pal16_t
 {
 	uint8_t r, g, b;
-} pal16;
+}
+#ifdef __GNUC__
+__attribute__ ((packed))
+#endif
+pal16;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 void setCustomPalColor(uint32_t color);
 


### PR DESCRIPTION
Found another problematic type. It's packed by default by gcc to 3 bytes, but I'm not exactly sure why. I think it's better to explicitly do that instead, at least that fixes the crash I was seeing when running on Plan 9.