### PR TITLE
Allow using external libflac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 
 project(ft2-clone)
 
+option(EXTERNAL_LIBFLAC "use external(system) flac library" OFF)
+
 find_package(SDL2 REQUIRED)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${ft2-clone_SOURCE_DIR}/release/other/")
 
@@ -13,7 +15,6 @@ file(GLOB ft2-clone_SRC
     "${ft2-clone_SOURCE_DIR}/src/scopes/*.c"
     "${ft2-clone_SOURCE_DIR}/src/modloaders/*.c"
     "${ft2-clone_SOURCE_DIR}/src/smploaders/*.c"
-    "${ft2-clone_SOURCE_DIR}/src/libflac/*.c"
 )
 
 add_executable(ft2-clone ${ft2-clone_SRC})
@@ -33,6 +34,19 @@ target_compile_definitions(ft2-clone
     PRIVATE HAS_MIDI
     PRIVATE __LINUX_ALSA__
     PRIVATE HAS_LIBFLAC)
+
+if(EXTERNAL_LIBFLAC)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(FLAC REQUIRED IMPORTED_TARGET flac)
+    target_compile_definitions(ft2-clone
+        PRIVATE EXTERNAL_LIBFLAC)
+    target_link_libraries(ft2-clone
+        PRIVATE PkgConfig::FLAC)
+else()
+    file(GLOB flac_SRCS
+        "${ft2-clone_SOURCE_DIR}/src/libflac/*.c")
+    target_sources(ft2-clone PRIVATE ${flac_SRCS})
+endif()
 
 install(TARGETS ft2-clone
     RUNTIME DESTINATION bin)

--- a/src/smploaders/ft2_load_flac.c
+++ b/src/smploaders/ft2_load_flac.c
@@ -25,7 +25,12 @@
 #include "../ft2_sample_ed.h"
 #include "../ft2_sysreqs.h"
 #include "../ft2_sample_loader.h"
+
+#ifdef EXTERNAL_LIBFLAC
+#include <FLAC/stream_decoder.h>
+#else
 #include "../libflac/FLAC/stream_decoder.h"
+#endif
 
 static bool sample16Bit;
 static int16_t stereoSampleLoadMode = -1;


### PR DESCRIPTION
Package developers are usually against using bundled libs.
Lets help them out by providing a way of using the
installed libflac. The default behavior is the same as
before.