### PR TITLE
Fix compilation failure on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,11 @@ target_compile_definitions(ft2-clone
 if(UNIX)
     if(APPLE)
         find_library(COREAUDIO CoreAudio REQUIRED)
+        find_library(COREFOUNDATION CoreFoundation REQUIRED)
         find_library(COREMIDI CoreMIDI REQUIRED)
+        find_library(ICONV iconv REQUIRED)
         target_link_libraries(ft2-clone
-            PRIVATE ${COREAUDIO} ${COREMIDI})
+            PRIVATE ${COREAUDIO} ${COREMIDI} ${COREFOUNDATION} ${ICONV})
         target_compile_definitions(ft2-clone
             PRIVATE __MACOSX_CORE__)
     else()


### PR DESCRIPTION
Before this change, cmake was not able to link CoreFoundation and iconv correctly

<img width="1028" alt="Screenshot 2024-11-07 at 9 24 44 PM" src="https://github.com/user-attachments/assets/cc335730-3e7a-4078-b798-3cfd898faed0">
<img width="961" alt="Screenshot 2024-11-07 at 9 24 20 PM" src="https://github.com/user-attachments/assets/85e674ca-2036-41fa-9e7a-73f89f4b687f">
