### PR TITLE
When possible, match 'Save as' with format of opened module

### DIFF
--- a/src/ft2_module_loader.c
+++ b/src/ft2_module_loader.c
@@ -213,6 +213,14 @@ static bool doLoadMusic(bool externalThreadFlag)
 		goto loadError;
 
 	moduleLoaded = true;
+
+  switch (format)
+  {
+    case FORMAT_XM: editor.moduleSaveMode = MOD_SAVE_MODE_XM; break;
+    case FORMAT_MOD: editor.moduleSaveMode = MOD_SAVE_MODE_MOD; break;
+    default: editor.moduleSaveMode = MOD_SAVE_MODE_WAV; break;
+  }
+
 	return true;
 
 loadError:


### PR DESCRIPTION
Hi Olav!

It might be beneficial to have the ‘Save as’ format automatically match the opened module’s format by default, falling back to .wav unless the file is a .mod or .xm.

Loving both the FT2 and Protracker clone btw! :)