### PR TITLE
Fix CMake for musl-based libc systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ if(UNIX)
         target_compile_definitions(ft2-clone
             PRIVATE __MACOSX_CORE__)
     else()
+        # musl systems need musl-fts installed, others have it with glibc
+        find_library(FTS fts)
+        if (FTS)
+            target_link_libraries(ft2-clone PRIVATE fts)
+        endif()
         target_link_libraries(ft2-clone
             PRIVATE asound)
         target_compile_definitions(ft2-clone


### PR DESCRIPTION
This PR should fix cmake-builds on musl-based systems like Alpine Linux. They require an additional library to be installed `musl-fts-dev`.

I tested building this PR on Debian 13 to ensure this didn't break existing Linux builds and it seemed to be fine.