### PR TITLE
Fix diskop not working on musl systems

### DIFF
--- a/src/ft2_diskop.c
+++ b/src/ft2_diskop.c
@@ -20,6 +20,7 @@
 #include <fts.h> // for fts_open() and stuff in recursiveDelete()
 #include <unistd.h>
 #include <dirent.h>
+#include <errno.h>
 #endif
 #include <wchar.h>
 #include <sys/stat.h>
@@ -1753,7 +1754,7 @@ static void displayCurrPath(void)
 	char *asciiPath = unicharToCp850(FReq_CurPathU, true);
 	if (asciiPath == NULL)
 	{
-		okBox(0, "System message", "Not enough memory!", NULL);
+		okBox(0, "System message", "Could not get CWD!", NULL);
 		return;
 	}
 

--- a/src/ft2_unicode.c
+++ b/src/ft2_unicode.c
@@ -3,6 +3,23 @@
 #include <crtdbg.h>
 #endif
 
+// for detecting if musl or glibc is used
+#ifndef _WIN32
+	#ifndef _GNU_SOURCE
+		#define _GNU_SOURCE
+	  #include <features.h>
+	  #ifndef __USE_GNU
+	      #define __MUSL__
+	  #endif
+	  #undef _GNU_SOURCE /* don't contaminate other includes unnecessarily */
+	#else
+	  #include <features.h>
+	  #ifndef __USE_GNU
+	      #define __MUSL__
+	  #endif
+	#endif
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
@@ -285,6 +302,8 @@ char *utf8ToCp850(char *src, bool removeIllegalChars)
 	iconv_t cd = iconv_open("850//TRANSLIT//IGNORE", "UTF-8-MAC");
 #elif defined(__NetBSD__) || defined(__sun) || defined(sun)
 	iconv_t cd = iconv_open("850", "UTF-8");
+#elif defined(__MUSL__)
+	iconv_t cd = iconv_open("cp850", "UTF-8");
 #else
 	iconv_t cd = iconv_open("850//TRANSLIT//IGNORE", "UTF-8");
 #endif


### PR DESCRIPTION
This PR fixes not being able to do any disk operations on a musl-based system. Also changes one error to maybe being more clear.

For some reason the musl version of iconv has the codepages named differently from glibc. It also lacks support for `//IGNORE` and [`//TRANSLIT`](https://wiki.musl-libc.org/functional-differences-from-glibc.html#iconv), so we opt for the same solution as on BSD.